### PR TITLE
From in32 to int64 node IDs

### DIFF
--- a/src/osm/pyosm.py
+++ b/src/osm/pyosm.py
@@ -107,7 +107,7 @@ class Way(object):
         self.osm_parent = osm_parent
 
         if load_nodes:
-            self.__nodes = numpy.asarray(nodes, dtype='int32')
+            self.__nodes = numpy.asarray(nodes, dtype='int64')
         if load_attrs:
             self.__attrs = Attributes(attrs)
         if load_tags:


### PR DESCRIPTION
Since February 2013, OSM uses 64bit identifiers. See http://wiki.openstreetmap.org/wiki/64-bit_Identifiers

I ran into a bug creating a multipolygon for several cities, since the node ids became negative. This fixes the issue.
