### PR TITLE
64bit identifiers

### DIFF
--- a/src/osm/pyosm.py
+++ b/src/osm/pyosm.py
@@ -157,7 +157,7 @@ class Relation(object):
         self.osm_parent = osm_parent
 
         if load_members:
-            self.__members = numpy.array(members, dtype=[('type','|S1'),('id','<i4'),('role',numpy.object_)])
+            self.__members = numpy.array(members, dtype=[('type','|S1'),('id','<i8'),('role',numpy.object_)])
         if load_attrs:
             self.__attrs = Attributes(attrs)
         if load_tags:


### PR DESCRIPTION
I've stepped on another issue because  "Since February 2013, OSM uses 64bit identifiers"

It is addition to marians commit d9cef6f17f8aeb63f92cb93019c57fc26fd4f4ab "Changed int32 to int64"
